### PR TITLE
fix(bin): use tsx from declapract node_modules not consumer cwd

### DIFF
--- a/.behavior/v2026_06_12.fix-node-v22/.route/.bouncer.cache.json
+++ b/.behavior/v2026_06_12.fix-node-v22/.route/.bouncer.cache.json
@@ -1,0 +1,3 @@
+{
+  "protections": []
+}

--- a/.behavior/v2026_06_12.fix-node-v22/.route/.drive.blockers.latest.json
+++ b/.behavior/v2026_06_12.fix-node-v22/.route/.drive.blockers.latest.json
@@ -1,0 +1,4 @@
+{
+  "count": 3,
+  "stone": "1.vision"
+}

--- a/bin/run
+++ b/bin/run
@@ -9,9 +9,11 @@
 const hasTsxLoader = process.execArgv.some((arg) => arg.includes('tsx'));
 if (!hasTsxLoader) {
   const { spawnSync } = require('child_process');
+  // resolve tsx/esm from declapract's own node_modules, not consumer's cwd
+  const tsxEsmPath = require.resolve('tsx/esm');
   const result = spawnSync(
     process.execPath,
-    ['--import', 'tsx/esm', ...process.execArgv, __filename, ...process.argv.slice(2)],
+    ['--import', tsxEsmPath, ...process.execArgv, __filename, ...process.argv.slice(2)],
     { stdio: 'inherit' },
   );
   process.exit(result.status ?? 1);


### PR DESCRIPTION
fix(bin): use tsx from declapract node_modules not consumer cwd

- require.resolve tsx/esm to get absolute path from declapract deps
- fixes ERR_MODULE_NOT_FOUND when consumer project lacks tsx

---
🐢🌊 surfed in by seaturtle[bot]